### PR TITLE
Fixed Github API Deprecation Notice

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -47,13 +47,18 @@ class Smashing_Updater {
 
 	private function get_repository_info() {
 	    if ( is_null( $this->github_response ) ) { // Do we have a response?
+		$args = array();
 	        $request_uri = sprintf( 'https://api.github.com/repos/%s/%s/releases', $this->username, $this->repository ); // Build URI
 
 	        if( $this->authorize_token ) { // Is there an access token?
-	            $request_uri = add_query_arg( 'access_token', $this->authorize_token, $request_uri ); // Append it
+	            $args = array(
+			"headers" => array(
+				"Authorization" => "token {$this->authorize_token}"
+			)
+		    );
 	        }
 
-	        $response = json_decode( wp_remote_retrieve_body( wp_remote_get( $request_uri ) ), true ); // Get JSON and parse it
+	        $response = json_decode( wp_remote_retrieve_body( wp_remote_get( $request_uri, $args ) ), true ); // Get JSON and parse it
 
 	        if( is_array( $response ) ) { // If it is an array
 	            $response = current( $response ); // Get the first item


### PR DESCRIPTION
Fixed Deprecation notice for authentication via URL query parameters

Personal access tokens can no longer be used as part of a query parameter to access an endpoint through the GitHub API

Send the token as a Header instead