### PR TITLE
Fix Notice Github API Deprecation 

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -151,7 +151,9 @@ class Smashing_Updater {
 	public function download_package( $args, $url ) {
 
 		if ( null !== $args['filename'] ) {
-			$args = array_merge( $args, array( "headers" => array( "Authorization" => "token {$this->authorize_token}" ) ) );
+			if( $this->authorize_token ) { 
+				$args = array_merge( $args, array( "headers" => array( "Authorization" => "token {$this->authorize_token}" ) ) );
+			}
 		}
 		
 		remove_filter( 'http_request_args', [ $this, 'download_package' ] );


### PR DESCRIPTION
- [x] Update wp_remote_get
- [x] Remove access_token
- [x] Append header authorization to download_package request

**Update wp_remote_get:** Append header authorization token to wp_remote_get as suggested in another pull request.

**Remove access_token:** Remove append of access_token to zip_ballurl

**Append header authorization to download_package request:** For file download authentication, add upgrader_pre_download and http_request_args filter to initialize. Override default download_package behavior.

```
add_filter( 'upgrader_pre_download',
	function() {
		add_filter( 'http_request_args', [ $this, 'download_package' ], 15, 2 );
		return false; // upgrader_pre_download filter default return value.
	}
);
```

Append authorization token to package_download
```
public function download_package( $args, $url ) {

	if ( null !== $args['filename'] ) {
		if( $this->authorize_token ) { 
			$args = array_merge( $args, array( "headers" => array( "Authorization" => "token {$this->authorize_token}" ) ) );
		}
	}

	remove_filter( 'http_request_args', [ $this, 'download_package' ] );

	return $args;
}
```



Concepts borrowed from https://github.com/afragen/github-updater/blob/0ce8da24d868ddc1195cdccdbb749ab7991f5a5d/src/GitHub_Updater/Init.php